### PR TITLE
Port to Gtk3 and GI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.stack-work
 dist

--- a/gtk-traymanager.cabal
+++ b/gtk-traymanager.cabal
@@ -22,10 +22,15 @@ description: This package provides a wrapper around the prolific eggtraymanager 
 library
   default-language: Haskell2010
   exposed-modules: Graphics.UI.Gtk.Misc.TrayManager
-  build-depends: gtk >= 0.12.1 && < 0.15,
-                 glib >= 0.12.1 && < 0.15,
-                 base > 3 && < 5
-  pkgconfig-depends: gtk+-2.0, x11
+  build-depends: base > 3 && < 5
+               , gi-gdk
+               , gi-gobject
+               , gi-gtk
+               , gi-glib
+               , haskell-gi-base
+               , text
+
+  pkgconfig-depends: gtk+-3.0, x11
   hs-source-dirs: src
   c-sources: src/c/eggtraymanager.c, src/c/eggmarshalers.c, src/c/gdk-helper.c
   ghc-options: -Wall

--- a/src/Graphics/UI/Gtk/Misc/TrayManager.hs
+++ b/src/Graphics/UI/Gtk/Misc/TrayManager.hs
@@ -16,17 +16,28 @@
 --
 -- As an example, a functional system tray widget looks something like:
 --
--- > import Graphics.UI.Gtk
+-- > import GI.Gdk.Objects.Display
+-- > import GI.Gtk
 -- > import Graphics.UI.Gtk.Misc.TrayManager
+-- >
 -- > systrayNew = do
--- >   box <- hBoxNew False 5
--- >   trayManager <- rayManagerNew
--- >   Just screen <- screenGetDefault
--- >   trayManagerManageScreen trayManager screen
--- >   on trayManager trayIconAdded $ \w -> do
--- >     widgetShowAll w
--- >     boxPackStart box w PackNatural 0
---
+-- >     box <- boxNew OrientationHorizontal 5
+-- >
+-- >     trayManager <- trayManagerNew
+-- >     Just disp <- displayGetDefault
+-- >     screen <- displayGetScreen disp 0
+-- >
+-- >     trayManagerManageScreen trayManager screen
+-- >
+-- >     onTrayIconAdded trayManager $ \w -> do
+-- >         widgetShowAll w
+-- >         boxPackStart box w False False 0
+-- >
+-- >     widgetSetSizeRequest box (-1) 25  -- bar height
+-- >
+-- >     widgetShowAll box
+-- >     toWidget box
+
 -- Note that the widgets made available in the event handlers are not
 -- shown by default; you need to explicitly show them if you want that
 -- (and you probably do).

--- a/src/Graphics/UI/Gtk/Misc/TrayManager.hs
+++ b/src/Graphics/UI/Gtk/Misc/TrayManager.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ForeignFunctionInterface, EmptyDataDecls #-}
+{-# LANGUAGE ScopedTypeVariables, CPP, OverloadedStrings, NegativeLiterals, ConstraintKinds, TypeFamilies, MultiParamTypeClasses, KindSignatures, FlexibleInstances, UndecidableInstances, DataKinds, FlexibleContexts #-}
 -- | This module implements a TrayManager - an integral part of a
 -- Linux system tray widget, though it is not itself a widget.  This
 -- package exports a single GObject (for use with gtk2hs) that
@@ -33,11 +33,11 @@
 module Graphics.UI.Gtk.Misc.TrayManager (
   -- * Types
   TrayManager,
-  TrayManagerChild,
-  TrayManagerClass,
-  castToTrayManager,
+  TrayManagerK,
   toTrayManager,
-  gTypeTrayManager,
+  noTrayManager,
+
+  TrayManagerChild,
 
   -- * Functions
   trayManagerCheckRunning,
@@ -46,87 +46,86 @@ module Graphics.UI.Gtk.Misc.TrayManager (
   trayManagerGetChildTitle,
 
   -- * Signals
-  trayIconAdded,
-  trayIconRemoved,
-  trayMessageSent,
-  trayMessageCanceled,
-  trayLostSelection
+  onTrayIconAdded,
+  -- TODO
+  -- onTrayIconRemoved,
+  -- onTrayMessageSent,
+  -- onTrayMessageCanceled,
+  -- onTrayLostSelection
   ) where
 
-import Graphics.UI.Gtk hiding ( after )
-import Graphics.UI.Gtk.Abstract.Object ( makeNewObject )
-import Graphics.UI.GtkInternals
-import System.Glib.GError ( failOnGError )
-import System.Glib.GType
-import System.Glib.UTFString ( peekUTFString )
+import Prelude ()
+import Data.GI.Base.ShortPrelude
 
-import Control.Monad ( liftM )
+import qualified Data.Text as T
+
+import qualified GI.GObject as GObject
+
+import GI.Gdk.Objects.Screen
+
+import GI.Gtk
 
 import Foreign
-import Foreign.C.String ( CString, peekCString )
 import Foreign.C.Types
-import Foreign.ForeignPtr.Unsafe as UF
 import Unsafe.Coerce ( unsafeCoerce )
 
 newtype TrayManager = TrayManager (ForeignPtr TrayManager)
-                    deriving (Eq, Ord)
+foreign import ccall "egg_tray_manager_get_type"
+  c_egg_tray_manager_get_type :: IO GType
+
+type instance ParentTypes TrayManager = TrayManagerParentTypes
+type TrayManagerParentTypes = '[Widget, GObject.Object]
+
+instance GObject TrayManager where
+    gobjectIsInitiallyUnowned _ = True
+    gobjectType _ = c_egg_tray_manager_get_type
+
+class GObject o => TrayManagerK o
+instance (GObject o, IsDescendantOf TrayManager o) => TrayManagerK o
+
+toTrayManager :: TrayManagerK o => o -> IO TrayManager
+toTrayManager = unsafeCastTo TrayManager
+
+noTrayManager :: Maybe TrayManager
+noTrayManager = Nothing
+
+foreign import ccall "egg_tray_manager_new"
+  egg_tray_manager_new :: IO (Ptr TrayManager)
+
+trayManagerNew :: MonadIO m => m TrayManager
+trayManagerNew = liftIO $ do
+    result <- egg_tray_manager_new
+    checkUnexpectedReturnNULL "egg_tray_manager_new" result
+    result' <- (newObject TrayManager) result
+    return result'
+
+--------------------
+
 type TrayManagerChild = Ptr EggTrayManagerChild
 
 -- Empty data tags to classify some foreign pointers
-data EggTrayManager
 data EggTrayManagerChild
 
 foreign import ccall "egg_tray_manager_check_running"
   c_egg_tray_manager_check_running :: Ptr Screen -> IO CInt
 
-trayManagerCheckRunning :: Screen -> IO Bool
-trayManagerCheckRunning gdkScreen = do
+trayManagerCheckRunning :: MonadIO m => Screen -> m Bool
+trayManagerCheckRunning gdkScreen = liftIO $ do
   let ptrScreen = unsafeCoerce gdkScreen :: ForeignPtr Screen
   withForeignPtr ptrScreen $ \realPtr -> do
     res <- c_egg_tray_manager_check_running realPtr
     return (res /= 0)
 
-mkTrayManager :: (ForeignPtr TrayManager -> TrayManager, FinalizerPtr a)
-mkTrayManager = (TrayManager, objectUnrefFromMainloop)
-
-unTrayManager :: TrayManager -> ForeignPtr TrayManager
-unTrayManager (TrayManager o) = o
-
-class GObjectClass o => TrayManagerClass o
-toTrayManager :: TrayManagerClass o => o -> TrayManager
-toTrayManager = unsafeCastGObject . toGObject
-
-instance TrayManagerClass TrayManager
-instance ObjectClass TrayManager
-instance GObjectClass TrayManager where
-  toGObject = GObject . castForeignPtr . unTrayManager
-  unsafeCastGObject = TrayManager . castForeignPtr . unGObject
-
-castToTrayManager :: GObjectClass o => o -> TrayManager
-castToTrayManager = castTo gTypeTrayManager "TrayManager"
-
-foreign import ccall "egg_tray_manager_get_type"
-  c_egg_tray_manager_get_type :: CULong
-
-gTypeTrayManager :: GType
-gTypeTrayManager = fromIntegral c_egg_tray_manager_get_type
-
-foreign import ccall "egg_tray_manager_new"
-  c_egg_tray_manager_new :: IO (Ptr EggTrayManager)
-
-trayManagerNew :: IO TrayManager
-trayManagerNew =
-  makeNewObject mkTrayManager $ liftM (castPtr :: Ptr EggTrayManager -> Ptr TrayManager) $
-    c_egg_tray_manager_new
-  -- tm <- c_egg_tray_manager_new
-  -- return (unsafeCoerce tm)
-
 foreign import ccall "egg_tray_manager_manage_screen"
-  c_egg_tray_manager_manage_screen :: Ptr EggTrayManager -> Ptr Screen -> IO CInt
+  c_egg_tray_manager_manage_screen :: Ptr TrayManager -> Ptr Screen -> IO CInt
 
-trayManagerManageScreen :: TrayManager -> Screen -> IO Bool
-trayManagerManageScreen trayManager screen = do
-  let ptrManager = unsafeCoerce trayManager :: ForeignPtr EggTrayManager
+trayManagerManageScreen ::
+    (MonadIO m, TrayManagerK a) =>
+    a
+    -> Screen
+    -> m Bool
+trayManagerManageScreen trayManager screen = liftIO $ do
+  let ptrManager = unsafeCoerce trayManager :: ForeignPtr TrayManager
       ptrScreen = unsafeCoerce screen :: ForeignPtr Screen
   res <- withForeignPtr ptrManager $ \realManager -> do
     withForeignPtr ptrScreen $ \realScreen -> do
@@ -134,22 +133,57 @@ trayManagerManageScreen trayManager screen = do
   return (res /= 0)
 
 foreign import ccall "egg_tray_manager_get_child_title"
-  c_egg_tray_manager_get_child_title :: Ptr EggTrayManager -> Ptr EggTrayManagerChild -> IO (Ptr CChar)
+  c_egg_tray_manager_get_child_title :: Ptr TrayManager -> Ptr EggTrayManagerChild -> IO (Ptr CChar)
 
 
-trayManagerGetChildTitle :: TrayManager -> TrayManagerChild -> IO String
+trayManagerGetChildTitle :: TrayManager -> TrayManagerChild -> IO T.Text
 trayManagerGetChildTitle trayManager child = do
-  let ptrManager = unsafeCoerce trayManager :: ForeignPtr EggTrayManager
+  let ptrManager = unsafeCoerce trayManager :: ForeignPtr TrayManager
   res <- withForeignPtr ptrManager $ \realManager -> do
     c_egg_tray_manager_get_child_title realManager child
-  peekCString res
+  cstringToText res
 
 -- | The signal emitted when a new tray icon is added.  These are
 -- delivered even for systray icons that already exist when the tray
 -- manager is created.
-trayIconAdded :: (TrayManagerClass self) => Signal self (Widget -> IO ())
-trayIconAdded = Signal (connect_OBJECT__NONE "tray_icon_added")
 
+type TrayIconAddedCallback = Widget -> IO ()
+
+type TrayIconAddedCallbackC =
+    Ptr () ->
+    Ptr Widget ->
+    Ptr () ->
+    IO ()
+
+foreign import ccall "wrapper"
+    mkTrayIconAddedCallback :: TrayIconAddedCallbackC -> IO (FunPtr TrayIconAddedCallbackC)
+
+trayIconAddedClosure :: TrayIconAddedCallback -> IO Closure
+trayIconAddedClosure cb = newCClosure =<< mkTrayIconAddedCallback wrapped
+    where wrapped = trayIconAddedCallbackWrapper cb
+
+trayIconAddedCallbackWrapper ::
+    TrayIconAddedCallback ->
+    Ptr () ->
+    Ptr Widget ->
+    Ptr () ->
+    IO ()
+trayIconAddedCallbackWrapper _cb _ object _ = do
+    object' <- (newObject Widget) object
+    _cb  object'
+
+onTrayIconAdded :: (GObject a, MonadIO m) => a -> TrayIconAddedCallback -> m SignalHandlerId
+onTrayIconAdded obj cb = liftIO $ connectTrayIconAdded obj cb SignalConnectBefore
+afterTrayIconAdded :: (GObject a, MonadIO m) => a -> TrayIconAddedCallback -> m SignalHandlerId
+afterTrayIconAdded obj cb = connectTrayIconAdded obj cb SignalConnectAfter
+
+connectTrayIconAdded :: (GObject a, MonadIO m) =>
+                         a -> TrayIconAddedCallback -> SignalConnectMode -> m SignalHandlerId
+connectTrayIconAdded obj cb after = liftIO $ do
+    cb' <- mkTrayIconAddedCallback (trayIconAddedCallbackWrapper cb)
+    connectSignalFunPtr obj "tray_icon_added" cb' after
+
+{-
 -- | This signal is emitted when a tray icon is removed by its parent
 -- application.  No action is really necessary here (the icon is
 -- removed without any intervention).  You could do something here if
@@ -171,70 +205,4 @@ trayMessageCanceled = Signal (connect_OBJECT_INT64__NONE "message_canceled")
 -- | ??
 trayLostSelection :: (TrayManagerClass self) => Signal self (IO ())
 trayLostSelection = Signal (connect_NONE__NONE "lost_selection")
-
-
--- Boilerplate stolen from gtk to make this library compatible.  These
--- functions aren't exported at all so I just copied them.
-
--- stolen from gtk
-castTo :: (GObjectClass obj, GObjectClass obj') => GType -> String -> (obj -> obj')
-castTo gtype objTypeName obj =
-  case toGObject obj of
-    gobj@(GObject objFPtr)
-      | typeInstanceIsA ((UF.unsafeForeignPtrToPtr.castForeignPtr) objFPtr) gtype
-                  -> unsafeCastGObject gobj
-      | otherwise -> error $ "Cannot cast object to " ++ objTypeName
-
-connect_OBJECT__NONE ::
-  (GObjectClass a', GObjectClass obj) => SignalName ->
-  ConnectAfter -> obj ->
-  (a' -> IO ()) ->
-  IO (ConnectId obj)
-connect_OBJECT__NONE signal after obj user =
-  connectGeneric signal after obj action
-  where action :: Ptr GObject -> Ptr GObject -> IO ()
-        action _ obj1 =
-          failOnGError $
-          makeNewGObject (GObject, objectUnrefFromMainloop) (return obj1) >>= \obj1' ->
-          user (unsafeCastGObject obj1')
-
-connect_NONE__NONE ::
-  GObjectClass obj => SignalName ->
-  ConnectAfter -> obj ->
-  (IO ()) ->
-  IO (ConnectId obj)
-connect_NONE__NONE signal after obj user =
-  connectGeneric signal after obj action
-  where action :: Ptr GObject -> IO ()
-        action _ =
-          failOnGError $
-          user
-
-connect_OBJECT_INT64__NONE :: (GObjectClass a', GObjectClass obj)
-                              => SignalName
-                              -> ConnectAfter
-                              -> obj
-                              -> (a' -> Int64 -> IO ())
-                              -> IO (ConnectId obj)
-connect_OBJECT_INT64__NONE signal after obj user =
-  connectGeneric signal after obj action
-  where
-    action :: Ptr GObject -> Ptr GObject -> Int64 -> IO ()
-    action _ obj1 int2 =
-      failOnGError $ makeNewGObject (GObject, objectUnrefFromMainloop) (return obj1) >>= \obj1' ->
-        user (unsafeCastGObject obj1') int2
-
-connect_OBJECT_STRING_INT64_INT64__NONE :: (GObjectClass a', GObjectClass obj)
-                                           => SignalName
-                                           -> ConnectAfter
-                                           -> obj
-                                           -> (a' -> String -> Int64 -> Int64 -> IO ())
-                                           -> IO (ConnectId obj)
-connect_OBJECT_STRING_INT64_INT64__NONE signal after obj user =
-  connectGeneric signal after obj action
-  where
-    action :: Ptr GObject -> Ptr GObject -> CString -> Int64 -> Int64 -> IO ()
-    action _ obj1 str2 int3 int4 =
-      failOnGError $ makeNewGObject (GObject, objectUnrefFromMainloop) (return obj1) >>= \obj1' ->
-        peekUTFString str2 >>= \str2' ->
-          user (unsafeCastGObject obj1') str2' int3 int4
+-}

--- a/src/c/eggtraymanager.c
+++ b/src/c/eggtraymanager.c
@@ -19,8 +19,8 @@
 
 #include <string.h>
 #include <gdk/gdkx.h>
-#include <gtk/gtkinvisible.h>
-#include <gtk/gtksocket.h>
+#include <gtk/gtk.h>
+#include <gtk/gtkx.h>
 #include <gtk/gtkwindow.h>
 #include "eggtraymanager.h"
 #include "eggmarshalers.h"
@@ -41,7 +41,7 @@ typedef struct
 {
   long id, len;
   long remaining_len;
-  
+
   long timeout;
   Window window;
   char *str;
@@ -100,12 +100,12 @@ static void
 egg_tray_manager_class_init (EggTrayManagerClass *klass)
 {
   GObjectClass *gobject_class;
-  
+
   parent_class = g_type_class_peek_parent (klass);
   gobject_class = (GObjectClass *)klass;
 
   gobject_class->finalize = egg_tray_manager_finalize;
-  
+
   manager_signals[TRAY_ICON_ADDED] =
     g_signal_new ("tray_icon_added",
 		  G_OBJECT_CLASS_TYPE (klass),
@@ -162,11 +162,11 @@ static void
 egg_tray_manager_finalize (GObject *object)
 {
   EggTrayManager *manager;
-  
+
   manager = EGG_TRAY_MANAGER (object);
 
   egg_tray_manager_unmanage (manager);
-  
+
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 
@@ -191,7 +191,7 @@ egg_tray_manager_plug_removed (GtkSocket       *socket,
   g_hash_table_remove (manager->socket_table, GINT_TO_POINTER (*window));
   g_object_set_data (G_OBJECT (socket), "egg-tray-child-window",
 		     NULL);
-  
+
   g_signal_emit (manager, manager_signals[TRAY_ICON_REMOVED], 0, socket);
 
   /* This destroys the socket. */
@@ -204,16 +204,16 @@ egg_tray_manager_handle_dock_request (EggTrayManager       *manager,
 {
   GtkWidget *socket;
   Window *window;
-  
+
   socket = gtk_socket_new ();
-  
+
   /* We need to set the child window here
    * so that the client can call _get functions
    * in the signal handler
    */
   window = g_new (Window, 1);
   *window = xevent->data.l[2];
-      
+
   g_object_set_data_full (G_OBJECT (socket),
 			  "egg-tray-child-window",
 			  window, g_free);
@@ -225,7 +225,7 @@ egg_tray_manager_handle_dock_request (EggTrayManager       *manager,
     {
       g_signal_connect (socket, "plug_removed",
 			G_CALLBACK (egg_tray_manager_plug_removed), manager);
-      
+
       gtk_socket_add_id (GTK_SOCKET (socket), xevent->data.l[2]);
 
       g_hash_table_insert (manager->socket_table, GINT_TO_POINTER (xevent->data.l[2]), socket);
@@ -247,7 +247,7 @@ egg_tray_manager_handle_message_data (EggTrayManager       *manager,
 {
   GList *p;
   int len;
-  
+
   /* Try to see if we can find the
    * pending message in the list
    */
@@ -277,7 +277,7 @@ egg_tray_manager_handle_message_data (EggTrayManager       *manager,
 		}
 	      manager->messages = g_list_remove_link (manager->messages,
 						      p);
-	      
+
 	      pending_message_free (msg);
 	    }
 
@@ -327,9 +327,9 @@ egg_tray_manager_handle_cancel_message (EggTrayManager       *manager,
 					XClientMessageEvent  *xevent)
 {
   GtkSocket *socket;
-  
+
   socket = g_hash_table_lookup (manager->socket_table, GINT_TO_POINTER (xevent->window));
-  
+
   if (socket)
     {
       g_signal_emit (manager, manager_signals[MESSAGE_CANCELLED], 0,
@@ -384,7 +384,7 @@ egg_tray_manager_window_filter (GdkXEvent *xev, GdkEvent *event, gpointer data)
       g_signal_emit (manager, manager_signals[LOST_SELECTION], 0);
       egg_tray_manager_unmanage (manager);
     }
-  
+
   return GDK_FILTER_CONTINUE;
 }
 
@@ -400,19 +400,19 @@ egg_tray_manager_unmanage (EggTrayManager *manager)
 
   invisible = manager->invisible;
   g_assert (GTK_IS_INVISIBLE (invisible));
-  g_assert (GTK_WIDGET_REALIZED (invisible));
-  g_assert (GDK_IS_WINDOW (invisible->window));
-  
-  display = GDK_WINDOW_XDISPLAY (invisible->window);
-  
+  g_assert (gtk_widget_get_realized (invisible));
+  g_assert (GDK_IS_WINDOW (gtk_widget_get_window (invisible)));
+
+  display = GDK_WINDOW_XDISPLAY (gtk_widget_get_window (invisible));
+
   if (XGetSelectionOwner (display, manager->selection_atom) ==
-      GDK_WINDOW_XWINDOW (invisible->window))
+      GDK_WINDOW_XID (gtk_widget_get_window (invisible)))
     {
-      timestamp = gdk_x11_get_server_time (invisible->window);      
+      timestamp = gdk_x11_get_server_time (gtk_widget_get_window (invisible));
       XSetSelectionOwner (display, manager->selection_atom, None, timestamp);
     }
 
-  gdk_window_remove_filter (invisible->window, egg_tray_manager_window_filter, manager);  
+  gdk_window_remove_filter (gtk_widget_get_window (invisible), egg_tray_manager_window_filter, manager);
 
   manager->invisible = NULL; /* prior to destroy for reentrancy paranoia */
   gtk_widget_destroy (invisible);
@@ -426,7 +426,7 @@ egg_tray_manager_manage_xscreen (EggTrayManager *manager, Screen *xscreen)
   char *selection_atom_name;
   guint32 timestamp;
   GdkScreen *screen;
-  
+
   g_return_val_if_fail (EGG_IS_TRAY_MANAGER (manager), FALSE);
   g_return_val_if_fail (manager->screen == NULL, FALSE);
 
@@ -439,10 +439,10 @@ egg_tray_manager_manage_xscreen (EggTrayManager *manager, Screen *xscreen)
 #endif
   screen = gdk_display_get_screen (gdk_x11_lookup_xdisplay (DisplayOfScreen (xscreen)),
 				   XScreenNumberOfScreen (xscreen));
-  
+
   invisible = gtk_invisible_new_for_screen (screen);
   gtk_widget_realize (invisible);
-  
+
   gtk_widget_add_events (invisible, GDK_PROPERTY_CHANGE_MASK | GDK_STRUCTURE_MASK);
 
   selection_atom_name = g_strdup_printf ("_NET_SYSTEM_TRAY_S%d",
@@ -450,14 +450,14 @@ egg_tray_manager_manage_xscreen (EggTrayManager *manager, Screen *xscreen)
   manager->selection_atom = XInternAtom (DisplayOfScreen (xscreen), selection_atom_name, False);
 
   g_free (selection_atom_name);
-  
-  timestamp = gdk_x11_get_server_time (invisible->window);
+
+  timestamp = gdk_x11_get_server_time (gtk_widget_get_window (invisible));
   XSetSelectionOwner (DisplayOfScreen (xscreen), manager->selection_atom,
-		      GDK_WINDOW_XWINDOW (invisible->window), timestamp);
+		      GDK_WINDOW_XID (gtk_widget_get_window (invisible)), timestamp);
 
   /* Check if we were could set the selection owner successfully */
   if (XGetSelectionOwner (DisplayOfScreen (xscreen), manager->selection_atom) ==
-      GDK_WINDOW_XWINDOW (invisible->window))
+      GDK_WINDOW_XID (gtk_widget_get_window (invisible)))
     {
       XClientMessageEvent xev;
 
@@ -468,7 +468,7 @@ egg_tray_manager_manage_xscreen (EggTrayManager *manager, Screen *xscreen)
       xev.format = 32;
       xev.data.l[0] = timestamp;
       xev.data.l[1] = manager->selection_atom;
-      xev.data.l[2] = GDK_WINDOW_XWINDOW (invisible->window);
+      xev.data.l[2] = GDK_WINDOW_XID (gtk_widget_get_window (invisible));
       xev.data.l[3] = 0;	/* manager specific data */
       xev.data.l[4] = 0;	/* manager specific data */
 
@@ -478,7 +478,7 @@ egg_tray_manager_manage_xscreen (EggTrayManager *manager, Screen *xscreen)
 
       manager->invisible = invisible;
       g_object_ref (G_OBJECT (manager->invisible));
-      
+
       manager->opcode_atom = XInternAtom (DisplayOfScreen (xscreen),
 					  "_NET_SYSTEM_TRAY_OPCODE",
 					  False);
@@ -488,13 +488,13 @@ egg_tray_manager_manage_xscreen (EggTrayManager *manager, Screen *xscreen)
 						False);
 
       /* Add a window filter */
-      gdk_window_add_filter (invisible->window, egg_tray_manager_window_filter, manager);
+      gdk_window_add_filter (gtk_widget_get_window (invisible), egg_tray_manager_window_filter, manager);
       return TRUE;
     }
   else
     {
       gtk_widget_destroy (invisible);
- 
+
       return FALSE;
     }
 }
@@ -506,7 +506,7 @@ egg_tray_manager_manage_screen (EggTrayManager *manager,
   g_return_val_if_fail (GDK_IS_SCREEN (screen), FALSE);
   g_return_val_if_fail (manager->screen == NULL, FALSE);
 
-  return egg_tray_manager_manage_xscreen (manager, 
+  return egg_tray_manager_manage_xscreen (manager,
 					  GDK_SCREEN_XSCREEN (screen));
 }
 
@@ -550,7 +550,7 @@ egg_tray_manager_get_child_title (EggTrayManager *manager,
 
   g_return_val_if_fail (EGG_IS_TRAY_MANAGER (manager), NULL);
   g_return_val_if_fail (GTK_IS_SOCKET (child), NULL);
-  
+
   child_window = g_object_get_data (G_OBJECT (child),
 				    "egg-tray-child-window");
 
@@ -566,7 +566,7 @@ egg_tray_manager_get_child_title (EggTrayManager *manager,
 			       False, utf8_string,
 			       &type, &format, &nitems,
 			       &bytes_after, (guchar **)&val);
-  
+
   if (gdk_error_trap_pop () || result != Success)
     return NULL;
 


### PR DESCRIPTION
I have a rough implementation of a Gtk3 port using GObject introspection with `haskell-gi` as a base, `gi-gtk` and friends. This is an invasive change - the API follows that of `gi-gtk`, not `gtk`. I can wrap the whole thing up nicely, but if you don't want to change the API, this will most likely be a perpetual fork. Would you prefer to adopt GI here, or for the GI version to be maintained separately?
